### PR TITLE
Fixes #75

### DIFF
--- a/src/main/webapp/app/entities/core/category/category-update.component.ts
+++ b/src/main/webapp/app/entities/core/category/category-update.component.ts
@@ -99,7 +99,8 @@ export class CategoryUpdateComponent implements OnInit {
         if (this.category.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/dega-user/dega-user-update.component.ts
+++ b/src/main/webapp/app/entities/core/dega-user/dega-user-update.component.ts
@@ -133,7 +133,8 @@ export class DegaUserUpdateComponent implements OnInit {
         if (this.degaUser.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/format/format-update.component.ts
+++ b/src/main/webapp/app/entities/core/format/format-update.component.ts
@@ -90,7 +90,8 @@ export class FormatUpdateComponent implements OnInit {
         if (this.format.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/organization/organization-update.component.ts
+++ b/src/main/webapp/app/entities/core/organization/organization-update.component.ts
@@ -105,7 +105,8 @@ export class OrganizationUpdateComponent implements OnInit {
         if (this.organization.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/post/post-update.component.ts
+++ b/src/main/webapp/app/entities/core/post/post-update.component.ts
@@ -212,7 +212,8 @@ export class PostUpdateComponent implements OnInit {
         if (this.post.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/role/role-update.component.ts
+++ b/src/main/webapp/app/entities/core/role/role-update.component.ts
@@ -90,7 +90,8 @@ export class RoleUpdateComponent implements OnInit {
         if (this.role.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/status/status-update.component.ts
+++ b/src/main/webapp/app/entities/core/status/status-update.component.ts
@@ -90,7 +90,8 @@ export class StatusUpdateComponent implements OnInit {
         if (this.status.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/core/tag/tag-update.component.ts
+++ b/src/main/webapp/app/entities/core/tag/tag-update.component.ts
@@ -99,7 +99,8 @@ export class TagUpdateComponent implements OnInit {
         if (this.tag.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/factcheck/claim/claim-update.component.ts
+++ b/src/main/webapp/app/entities/factcheck/claim/claim-update.component.ts
@@ -131,7 +131,8 @@ export class ClaimUpdateComponent implements OnInit {
         if (this.claim.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/factcheck/claimant/claimant-update.component.ts
+++ b/src/main/webapp/app/entities/factcheck/claimant/claimant-update.component.ts
@@ -70,7 +70,8 @@ export class ClaimantUpdateComponent implements OnInit {
         if (this.claimant.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/factcheck/factcheck/factcheck-update.component.ts
+++ b/src/main/webapp/app/entities/factcheck/factcheck/factcheck-update.component.ts
@@ -237,7 +237,8 @@ export class FactcheckUpdateComponent implements OnInit {
         if (this.factcheck.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;

--- a/src/main/webapp/app/entities/factcheck/rating/rating-update.component.ts
+++ b/src/main/webapp/app/entities/factcheck/rating/rating-update.component.ts
@@ -97,7 +97,8 @@ export class RatingUpdateComponent implements OnInit {
         if (this.rating.id === undefined) {
             this.slugExtention = 0;
             this.slug = event.target.value
-                .replace(/[;/?:@=&"<>#%{}|\^~]/g, '')
+                .replace(/[;/?:@=&"<>#%{}|\^~$-`“‘]/g, '')
+                .trim()
                 .replace(/\s+/g, '-')
                 .toLowerCase();
             this.tempSlug = this.slug;


### PR DESCRIPTION
Added a few more characters to remove from the slug
Used trim function to remove extra spaces before replacing spaces with -. This will avoid extra - before and after when creating slug.

@Ramesh-ns Also wondering if we should make this a reusable method, so we don't have to change in various places everytime if we have to trim new characters at a later time.